### PR TITLE
Robust svydesign handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,8 @@ LazyData: TRUE
 Depends: R (>= 4.0)
 Imports:
     survey (>= 4.1),
-    magrittr (>= 2.0)
+    magrittr (>= 2.0),
+    utils
 Suggests:
     dplyr (>= 1.0),
     ggplot2 (>= 3.3),

--- a/man/cv.svydesign.Rd
+++ b/man/cv.svydesign.Rd
@@ -14,7 +14,7 @@ cv.svydesign(
 }
 \arguments{
 \item{design_object}{Name of a \code{svydesign} object created using the \code{survey}
-package. We do not yet support use of \code{probs} or \code{pps}.}
+package. We do not yet support use of replicate designs.}
 
 \item{formulae}{Vector of formulas (as strings) for the GLMs to be compared in
 cross validation}

--- a/man/folds.svydesign.Rd
+++ b/man/folds.svydesign.Rd
@@ -8,8 +8,8 @@ folds.svydesign(design_object, nfolds)
 }
 \arguments{
 \item{design_object}{Name of a \code{svydesign} object created using the \code{survey}
-package. The arguments \code{id} and \code{strata} (if used)
-must be specified as formulas, e.g. \code{svydesign(ids = ~MyPSUs, ...)}.}
+package. Replicate designs are not currently supported, and only first-stage
+stratification and clusters are used.}
 
 \item{nfolds}{Number of folds to be used during cross validation}
 }
@@ -26,7 +26,7 @@ and passes it into \code{\link{folds.svy}}.
 Returns a vector of fold IDs, which in most cases you will want to append
 to your \code{svydesign} object using \code{update.svydesign}
 (see Examples below).
-These fold IDs respect any stratification or clustering in the survey design.
+These fold IDs respect any first-stage stratification or clustering in the survey design.
 You can then carry out K-fold CV as usual,
 taking care to also use the survey design features and survey weights
 when fitting models in each training set

--- a/tests/testthat/test-cv.svydesign.R
+++ b/tests/testthat/test-cv.svydesign.R
@@ -1,0 +1,161 @@
+suppressPackageStartupMessages({
+  library(survey)
+})
+
+data('api', package = 'survey')
+
+single_stage_design <- svydesign(data = apiclus1,
+                                 id = ~dnum, fpc = ~fpc,
+                                 weights = ~pw)
+multistage_design <- svydesign(data = apiclus2,
+                               id  = ~dnum + snum,
+                               fpc = ~fpc1 + fpc2)
+clustered_stratified_design <- svydesign(data = apiclus1,
+                                         id = ~dnum,
+                                         strata = ~ stype,
+                                         weights = ~ pw,
+                                         nest = TRUE)
+
+test_that("`cv.svydesign` matches `cv.svy`", {
+  # Single-stage unstratified cluster sample
+  set.seed(2022)
+  apiclus1[['STRATUM']] <- rep(1, nrow(apiclus1))
+  cv.svy_result <- cv.svy(
+    Data = apiclus1,
+    weightsID = "pw",
+    clusterID = "dnum",
+    strataID = "STRATUM",
+    fpcID = 'fpc',
+    nfolds = 5,
+    formulae = c("api00~ell",
+                 "api00~ell+meals",
+                 "api00~ell+meals+mobility"),
+    method = "linear"
+  )
+  set.seed(2022)
+  cv.svydesign_result <- cv.svydesign(
+    design_object = single_stage_design,
+    nfolds = 5,
+    formulae = c("api00~ell",
+                 "api00~ell+meals",
+                 "api00~ell+meals+mobility"),
+    method = "linear"
+  )
+  expect_equal(
+    object = cv.svydesign_result,
+    expected = cv.svy_result,
+    label = "Unstratified cluster design"
+  )
+
+  # Multistage unstratified cluster sample
+  set.seed(2022)
+  apiclus2[['STRATUM']] <- rep(1, nrow(apiclus2))
+  cv.svy_result <- cv.svy(
+    Data = apiclus2,
+    weightsID = "pw",
+    clusterID = "dnum",
+    strataID = "STRATUM",
+    fpc = "fpc1",
+    nfolds = 5,
+    formulae = c("api00~ell",
+                 "api00~ell+meals",
+                 "api00~ell+meals+mobility"),
+    method = "linear"
+  )
+
+  suppressWarnings({
+    set.seed(2022)
+    cv.svydesign_result <- cv.svydesign(
+      design_object = multistage_design,
+      nfolds = 5,
+      formulae = c("api00~ell",
+                   "api00~ell+meals",
+                   "api00~ell+meals+mobility"),
+      method = "linear"
+    )
+  })
+
+  expect_equal(
+    object = cv.svydesign_result,
+    expected = cv.svy_result,
+    label = "Multistage, unstratified cluster design"
+  )
+
+
+  # Single-stage, stratified cluster sample
+  apiclus1[['DNUM_BY_STYPE']] <- interaction(apiclus1$stype,
+                                             apiclus1$dnum,
+                                             sep = "|")
+  set.seed(2022)
+  cv.svy_result <- cv.svy(
+    Data = apiclus1,
+    weightsID = "pw",
+    clusterID = "DNUM_BY_STYPE",
+    strataID = "stype", nest = FALSE,
+    nfolds = 5,
+    formulae = c("api00~ell",
+                 "api00~ell+meals",
+                 "api00~ell+meals+mobility"),
+    method = "linear"
+  )
+  set.seed(2022)
+  cv.svydesign_result <- cv.svydesign(
+    design_object = clustered_stratified_design,
+    nfolds = 5,
+    formulae = c("api00~ell",
+                 "api00~ell+meals",
+                 "api00~ell+meals+mobility"),
+    method = "linear"
+  )
+  expect_equal(
+    object = cv.svy_result,
+    expected = cv.svydesign_result,
+    label = "Single-stage, stratified cluster design"
+  )
+
+})
+
+test_that("Informative warning for multistage designs", {
+  expect_warning(
+    object = {cv.svydesign(
+      design_object = multistage_design,
+      nfolds = 5,
+      formulae = c("api00~ell",
+                   "api00~ell+meals",
+                   "api00~ell+meals+mobility"),
+      method = "linear"
+    )
+      },
+    regexp = "Only first-stage clusters and strata will be used"
+  )
+})
+
+test_that("Informative error for replicate designs", {
+
+  replicate_design <- single_stage_design |>
+    as.svrepdesign(type = "JK1")
+  expect_error(
+    object = {cv.svydesign(
+      design_object = replicate_design,
+      nfolds = 5,
+      formulae = c("api00~ell",
+                   "api00~ell+meals",
+                   "api00~ell+meals+mobility"),
+      method = "linear"
+    )
+    },
+    regexp = "Replicate designs are not currently supported"
+  )
+})
+
+test_that("Informative error for non-design objects", {
+
+  expect_error(
+    object = {folds.svydesign(
+      design_object = apiclus1,
+      nfolds = 5
+    )
+    },
+    regexp = "must be a survey design object"
+  )
+})

--- a/tests/testthat/test-folds.svydesign.R
+++ b/tests/testthat/test-folds.svydesign.R
@@ -1,0 +1,124 @@
+suppressPackageStartupMessages({
+  library(survey)
+})
+
+data('api', package = 'survey')
+
+single_stage_design <- svydesign(data = apiclus1,
+                                 id = ~dnum, fpc = ~fpc,
+                                 weights = ~pw)
+multistage_design <- svydesign(data = apiclus2,
+                               id  = ~dnum + snum,
+                               fpc = ~fpc1 + fpc2)
+clustered_stratified_design <- svydesign(data = apiclus1,
+                                         id = ~dnum,
+                                         strata = ~ stype,
+                                         weights = ~ pw,
+                                         nest = TRUE)
+
+test_that("`folds.svydesign` matches `folds.svy`", {
+  # Single-stage unstratified cluster sample
+  set.seed(2022)
+  apiclus1[['STRATUM']] <- rep(1, nrow(apiclus1))
+  folds.svy_result <- folds.svy(
+    Data = apiclus1,
+    clusterID = "dnum",
+    strataID = "STRATUM",
+    nfolds = 5
+  )
+  set.seed(2022)
+  folds.svydesign_result <- folds.svydesign(
+    design_object = single_stage_design,
+    nfolds = 5
+  )
+  expect_equal(
+    object = folds.svydesign_result,
+    expected = folds.svy_result,
+    label = "Unstratified cluster design"
+  )
+
+  # Multistage unstratified cluster sample
+  set.seed(2022)
+  apiclus2[['STRATUM']] <- rep(1, nrow(apiclus2))
+  folds.svy_result <- folds.svy(
+    Data = apiclus2,
+    clusterID = "dnum",
+    strataID = "STRATUM",
+    nfolds = 5
+  )
+  suppressWarnings({
+    set.seed(2022)
+    folds.svydesign_result <- folds.svydesign(
+      design_object = multistage_design,
+      nfolds = 5
+    )
+  })
+  expect_equal(
+    object = folds.svydesign_result,
+    expected = folds.svy_result,
+    label = "Multistage, unstratified cluster design"
+  )
+
+
+  # Single-stage, stratified cluster sample
+  apiclus1[['DNUM_BY_STYPE']] <- interaction(apiclus1$stype,
+                                             apiclus1$dnum,
+                                             sep = "|")
+  set.seed(2022)
+  folds.svy_result <- folds.svy(
+    Data = apiclus1,
+    clusterID = "DNUM_BY_STYPE",
+    strataID = "stype",
+    nfolds = 5
+  )
+  set.seed(2022)
+  folds.svydesign_result <- folds.svydesign(
+    design_object = clustered_stratified_design,
+    nfolds = 5
+  )
+  expect_equal(
+    object = folds.svydesign_result,
+    expected = folds.svy_result,
+    label = "Single-stage, stratified cluster design"
+  )
+
+})
+
+test_that("Informative warning for multistage designs", {
+  expect_warning(
+    object = {folds.svydesign(
+      design_object = multistage_design,
+      nfolds = 5
+    )
+      },
+    regexp = "Only first-stage clusters and strata will be used"
+  )
+})
+
+test_that("Informative error for replicate designs", {
+
+  replicate_design <- single_stage_design |>
+    as.svrepdesign(type = "JK1")
+  expect_error(
+    object = {folds.svydesign(
+      design_object = replicate_design,
+      nfolds = 5
+    )
+    },
+    regexp = "Replicate designs are not currently supported"
+  )
+})
+
+test_that("Informative error for non-design objects", {
+
+  replicate_design <- single_stage_design |>
+    as.svrepdesign(type = "JK1")
+  expect_error(
+    object = {folds.svydesign(
+      design_object = apiclus1,
+      nfolds = 5
+    )
+    },
+    regexp = "must be a survey design object"
+  )
+})


### PR DESCRIPTION
This pull request changes the way that the functions `folds.svydesign()` and `cv.svydesign()` extract design information from a `survey.design` object. This makes these functions much safer, in that they now work with designs which have been subsetted or otherwise updated. They are also now compatible with survey designs from the ['srvyr' package](https://cran.r-project.org/web/packages/srvyr/index.html). This resolves Issue #3.
<details>
<summary>Click for details on 'robustifying' the `svydesign` functions</summary>

>Instead of using the `design_object$call` element, which is fragile for reasons discussed in #3, each design variable is pulled from the appropriate part of the design object (`design_object$strata`, `design_object$cluster`, `design_obj$fpc`). The weights are pulled by using `1/design$prob`, which is what the S3 method `weights(design_object)` does and is the way that the 'survey' package stores weights in general.
</details>

I also added informative warnings when the user supplies a survey design object with multiple stages of sampling, which warn the user that only first-stage sampling units and first-stage strata are used for cross-validation. In addition, I added an informative error message if the user attempts to supply a replicate design object or accidentally supplies a data frame instead of a survey design object.

As an aside, one thing this update doesn't improve is the handling of raked/post-stratified/calibrated survey design objects. This is because the `cv.svy()` function doesn't know how to handle calibration, and `cv.svydesign()` is essentially just a wrapper for `cv.svy()`. I think if the package design was changed so that `cv.svy()` was a wrapper around `cv.svydesign()` rather than the other way around, it could more easily handle raking/post-stratification/calibration. But I think that's an issue for another time, as it's not completely clear whether/how calibration should be taken into account, as you mention in the paper.

